### PR TITLE
Document pagination on public API module.

### DIFF
--- a/lib/apollo_io.ex
+++ b/lib/apollo_io.ex
@@ -43,6 +43,7 @@ defmodule ApolloIo do
 
   @doc """
   This endpoint searches for people. Calls to the search endpoint do not cost you credits. They also do not return any email information. To get email information, use the "enrich" endpoint.
+  This function support pagination by passing `page: page_number` to the list of parameters.
 
   ## Examples
       iex> ApolloIo.search([person_titles: ["sales director", "engineer manager"], q_organization_domains: "google.com\nfacebook.com", page: 1])


### PR DESCRIPTION
# Comment
As I mentioned, pagination is already [documented here](https://github.com/EnaiaInc/apollo_io/blob/main/lib/search.ex#L35) but this also make it obvious by mentioning it on the public API module.

Feel free to ignore if you think is redundant though.

Cheers.