### PR TITLE
Tweak API for `organization_enrich`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,16 @@ end
 ```
 
 ## Configuration
+
 The API key can be added to the config as follows in the `config.exs` or `runtime.exs`:
+
 ```elixir
 config :apollo_io,
   api_key: <YOUR_API_KEY>
 ```
 
 ## Usage
+
 No additional configuration is needed.
 Pass your api_key on every request:
 
@@ -33,15 +36,17 @@ ApolloIo.search(person_titles: ["sales director"])
 ```
 
 Supported params for `people_enrich` are:
-  - first_name (optional)
-  - last_name (optional)
-  - name (optional)
-  - email (optional)
-  - organization_name (optional)
-  - domain (optional)
-  - id (optional)
+
+- first_name (optional)
+- last_name (optional)
+- name (optional)
+- email (optional)
+- organization_name (optional)
+- domain (optional)
+- id (optional)
 
 Supported params for `organization_enrich` are:
-  - person_titles (options) - list os titles
-  - q_organization_domains (optional) - list of domains
-  - page (optional) - integer
+
+- person_titles (options) - list os titles
+- q_organization_domains (optional) - list of domains
+- page (optional) - integer

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pass your api_key on every request:
 
 ```elixir
 ApolloIo.people_enrich(email: "email@domain.com")
-ApolloIo.organization_enrich("some.domain.com")
+ApolloIo.organization_enrich(domain: "some.domain.com")
 ApolloIo.search(person_titles: ["sales director"])
 ```
 
@@ -47,6 +47,11 @@ Supported params for `people_enrich` are:
 
 Supported params for `organization_enrich` are:
 
-- person_titles (options) - list os titles
+- domain (required)
+
+Supported params for `search` are:
+
+- person_titles (optional) - list of titles
+- person_past_organization_ids (optional) - list of organization ids
 - q_organization_domains (optional) - list of domains
 - page (optional) - integer

--- a/lib/apollo_io.ex
+++ b/lib/apollo_io.ex
@@ -37,9 +37,9 @@ defmodule ApolloIo do
   This endpoint enriches a company with info such as industry, company size, etc. based on the domain parameter passed in.
 
   ## Examples
-      iex> ApolloIo.organization_enrich("patagonia.com")
+      iex> ApolloIo.organization_enrich(domain: "patagonia.com")
   """
-  defdelegate organization_enrich(domain), to: ApolloIo.Organization
+  defdelegate organization_enrich(opts), to: ApolloIo.Organization
 
   @doc """
   This endpoint searches for people. Calls to the search endpoint do not cost you credits. They also do not return any email information. To get email information, use the "enrich" endpoint.

--- a/lib/organization.ex
+++ b/lib/organization.ex
@@ -100,13 +100,20 @@ defmodule ApolloIo.Organization do
 
   @doc """
   Query the endpoint.
-  Required parameter is passed as a string.
-  - domain
+  Accepted values:
+  - domain (required)
   ref: https://apolloio.github.io/apollo-api-docs/?shell#organization-enrichment
+
+  Calling this function with a string is supported but discouraged.
   """
-  @spec organization_enrich(String.t()) :: {:ok, __MODULE__.t(), RateLimit.t()} | {:error, map()}
-  def organization_enrich(domain) do
-    opts = %{domain: domain}
+  @spec organization_enrich(Keyword.t() | String.t()) ::
+          {:ok, __MODULE__.t(), RateLimit.t()} | {:error, map()}
+  def organization_enrich(domain) when is_binary(domain) do
+    organization_enrich(domain: domain)
+  end
+
+  def organization_enrich(opts) do
+    opts = opts |> Enum.into(%{})
 
     case Request.get(@organization_match_url, opts) do
       {:ok, body, headers} ->

--- a/test/apollo_io_test.exs
+++ b/test/apollo_io_test.exs
@@ -27,6 +27,9 @@ defmodule ApolloIoTest do
       end)
 
       assert {:ok, %Organization{}, %RateLimit{minute: %{}, hourly: %{}, daily: %{}}} =
+               ApolloIo.organization_enrich(domain: "patagonia.com")
+
+      assert {:ok, %Organization{}, %RateLimit{minute: %{}, hourly: %{}, daily: %{}}} =
                ApolloIo.organization_enrich("patagonia.com")
     end
 
@@ -80,7 +83,8 @@ defmodule ApolloIoTest do
         )
       end)
 
-      {return_value, log} = with_log(fn -> ApolloIo.organization_enrich("patagonia.com") end)
+      {return_value, log} =
+        with_log(fn -> ApolloIo.organization_enrich(domain: "patagonia.com") end)
 
       assert {:error,
               %ApolloIo.Error{


### PR DESCRIPTION
Changes the API so that it is the same as other calls like `search`.
This makes it accept `api_key` option and makes it future proof

Fixes documentation

Note: previous API still supported
