### PR TITLE
Replace deprecated module.__struct__ usage

### DIFF
--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -59,7 +59,7 @@ defmodule ApolloIo.Helpers do
 
   def map_to_struct(map, module) do
     processed_map =
-      Map.keys(module.__struct__)
+      Map.keys(module.__struct__())
       |> List.delete(:__struct__)
       |> Enum.reduce(%{}, fn key, acc ->
         value =


### PR DESCRIPTION
We now do `module.__struct__()` in `map_to_struct/2`

Fixes https://www.pivotaltracker.com/story/show/188151438