### PR TITLE
Derive JSON.Encoder as well

### DIFF
--- a/lib/account.ex
+++ b/lib/account.ex
@@ -27,6 +27,7 @@ defmodule ApolloIo.Account do
         }
 
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/contact.ex
+++ b/lib/contact.ex
@@ -54,6 +54,7 @@ defmodule ApolloIo.Contact do
         }
 
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/employment.ex
+++ b/lib/employment.ex
@@ -22,6 +22,7 @@ defmodule ApolloIo.Employment do
           updated_at: DateTime.t()
         }
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,6 +1,7 @@
 defmodule ApolloIo.Error do
   @type t :: %__MODULE__{message: String.t()}
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
   defstruct [:message]
 end

--- a/lib/organization.ex
+++ b/lib/organization.ex
@@ -49,6 +49,7 @@ defmodule ApolloIo.Organization do
         }
 
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/pagination.ex
+++ b/lib/pagination.ex
@@ -9,6 +9,7 @@ defmodule ApolloIo.Pagination do
         }
 
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/person.ex
+++ b/lib/person.ex
@@ -32,6 +32,7 @@ defmodule ApolloIo.Person do
           employment_history: [Employment.t()]
         }
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/phone_number.ex
+++ b/lib/phone_number.ex
@@ -9,6 +9,7 @@ defmodule ApolloIo.PhoneNumber do
         }
 
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
 
   defstruct [

--- a/lib/rate_limit.ex
+++ b/lib/rate_limit.ex
@@ -4,6 +4,7 @@ defmodule ApolloIo.RateLimit do
   """
   @type t :: %__MODULE__{minute: map, hourly: map, daily: map}
   @derive Jason.Encoder
+  @derive JSON.Encoder
   use ApolloIo.Accessible
   defstruct [:minute, :hourly, :daily]
 

--- a/lib/search.ex
+++ b/lib/search.ex
@@ -14,6 +14,7 @@ defmodule ApolloIo.Search do
             people: [Person.t()]
           }
     @derive Jason.Encoder
+    @derive JSON.Encoder
     use ApolloIo.Accessible
 
     defstruct [


### PR DESCRIPTION
We will remove Jason.Encoder once we've migrated to JSON.Encoder in production.