### PR TITLE
[ENA-7867] Compute name from first_name/last_name when nil

### DIFF
--- a/lib/person.ex
+++ b/lib/person.ex
@@ -123,7 +123,16 @@ defmodule ApolloIo.Person do
     |> Map.update(:organization, nil, &Helpers.map_to_struct(&1, Organization))
     |> Map.update(:employment_history, [], &Helpers.map_list_to_struct(&1, Employment))
     |> Map.update(:phone_numbers, [], &Helpers.map_list_to_struct(&1, PhoneNumber))
+    |> compute_name_if_missing()
   end
+
+  defp compute_name_if_missing(%__MODULE__{name: nil, first_name: first, last_name: last} = person)
+       when not is_nil(first) or not is_nil(last) do
+    name = [first, last] |> Enum.reject(&is_nil/1) |> Enum.join(" ") |> String.trim()
+    %{person | name: if(name == "", do: nil, else: name)}
+  end
+
+  defp compute_name_if_missing(person), do: person
 
   @spec bulk_people_enrich([map()], keyword()) ::
           {:ok, [__MODULE__.t()], RateLimit.t()} | {:error, Request.error()}


### PR DESCRIPTION
## Summary

Fixes missing person names in Apollo search results by computing the name field from first_name and last_name when the API returns nil.

## Changes

- Add  function to Person module
- Called from  to ensure name is always populated when possible
- Handles cases where first_name and/or last_name exist but name is nil

## Context

The Apollo search API returns Person structs with first_name/last_name populated but name as nil, causing empty names in the Enaia suggested contacts UI.

Related: ENA-7867