### PR TITLE
[ENA-8069] Extract error messages from JSON error responses

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
 ExUnit.start()
 Application.ensure_all_started(:bypass)
+Application.put_env(:apollo_io, :api_key, "test_api_key")
+Application.put_env(:apollo_io, :base_url, "http://localhost:12345")


### PR DESCRIPTION
When Apollo.io API returns error responses with JSON bodies like {"error":"Rate limit exceeded"}, extract the error field value instead of passing the raw JSON string as the error message.

For malformed JSON responses, return the raw body as-is.

This improves error reporting in the Enaia application by providing cleaner error messages in AppSignal and logs.