### PR TITLE
[ENA-8181] Fix ArgumentError when rate limit headers contain non-numeric values

### DIFF
--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -30,22 +30,58 @@ defmodule ApolloIo.Helpers do
   end
 
   defp fetch_minute_map(headers) do
-    Enum.reduce(headers, %{}, fn {k, [v | _tail]}, acc ->
-      if k in @minute_values, do: Map.put(acc, parse_key(k), String.to_integer(v)), else: acc
+    default_map = %{usage: nil, limit: nil, requests_left: nil}
+
+    Enum.reduce(headers, default_map, fn {k, [v | _tail]}, acc ->
+      if k in @minute_values do
+        case safe_parse_integer(v) do
+          {:ok, int_value} -> Map.put(acc, parse_key(k), int_value)
+          :error -> acc
+        end
+      else
+        acc
+      end
     end)
   end
 
   defp fetch_hourly_map(headers) do
-    Enum.reduce(headers, %{}, fn {k, [v | _tail]}, acc ->
-      if k in @hourly_values, do: Map.put(acc, parse_key(k), String.to_integer(v)), else: acc
+    default_map = %{usage: nil, limit: nil, requests_left: nil}
+
+    Enum.reduce(headers, default_map, fn {k, [v | _tail]}, acc ->
+      if k in @hourly_values do
+        case safe_parse_integer(v) do
+          {:ok, int_value} -> Map.put(acc, parse_key(k), int_value)
+          :error -> acc
+        end
+      else
+        acc
+      end
     end)
   end
 
   defp fetch_daily_map(headers) do
-    Enum.reduce(headers, %{}, fn {k, [v | _tail]}, acc ->
-      if k in @daily_values, do: Map.put(acc, parse_key(k), String.to_integer(v)), else: acc
+    default_map = %{usage: nil, limit: nil, requests_left: nil}
+
+    Enum.reduce(headers, default_map, fn {k, [v | _tail]}, acc ->
+      if k in @daily_values do
+        case safe_parse_integer(v) do
+          {:ok, int_value} -> Map.put(acc, parse_key(k), int_value)
+          :error -> acc
+        end
+      else
+        acc
+      end
     end)
   end
+
+  defp safe_parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp safe_parse_integer(_value), do: :error
 
   defp parse_key(key) do
     cond do

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -1,0 +1,99 @@
+defmodule ApolloIo.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias ApolloIo.Helpers
+
+  describe "parse_headers/1" do
+    test "parses valid numeric header values" do
+      headers = [
+        {"x-minute-usage", ["10"]},
+        {"x-rate-limit-minute", ["100"]},
+        {"x-minute-requests-left", ["90"]},
+        {"x-hourly-usage", ["50"]},
+        {"x-rate-limit-hourly", ["1000"]},
+        {"x-hourly-requests-left", ["950"]},
+        {"x-24-hour-usage", ["200"]},
+        {"x-rate-limit-24-hour", ["10000"]},
+        {"x-24-hour-requests-left", ["9800"]}
+      ]
+
+      rate_limit = Helpers.parse_headers(headers)
+
+      assert rate_limit.minute.usage == 10
+      assert rate_limit.minute.limit == 100
+      assert rate_limit.minute.requests_left == 90
+
+      assert rate_limit.hourly.usage == 50
+      assert rate_limit.hourly.limit == 1000
+      assert rate_limit.hourly.requests_left == 950
+
+      assert rate_limit.daily.usage == 200
+      assert rate_limit.daily.limit == 10000
+      assert rate_limit.daily.requests_left == 9800
+    end
+
+    test "skips non-numeric header values gracefully" do
+      headers = [
+        {"x-minute-usage", ["10"]},
+        {"x-rate-limit-minute", ["100"]},
+        {"x-minute-requests-left", ["90"]},
+        # Non-numeric values that should be skipped
+        {"x-hourly-usage", ["..."]},
+        {"x-rate-limit-hourly", ["invalid"]},
+        {"x-hourly-requests-left", ["N/A"]},
+        {"x-24-hour-usage", ["200"]},
+        {"x-rate-limit-24-hour", ["10000"]},
+        {"x-24-hour-requests-left", ["9800"]}
+      ]
+
+      # Should not raise ArgumentError
+      rate_limit = Helpers.parse_headers(headers)
+
+      # Minute values should be present
+      assert rate_limit.minute.usage == 10
+      assert rate_limit.minute.limit == 100
+      assert rate_limit.minute.requests_left == 90
+
+      # Hourly values should be nil/empty (skipped due to invalid values)
+      assert rate_limit.hourly.usage == nil
+      assert rate_limit.hourly.limit == nil
+      assert rate_limit.hourly.requests_left == nil
+
+      # Daily values should be present
+      assert rate_limit.daily.usage == 200
+      assert rate_limit.daily.limit == 10000
+      assert rate_limit.daily.requests_left == 9800
+    end
+
+    test "handles partially numeric strings (should skip them)" do
+      headers = [
+        {"x-minute-usage", ["123abc"]},
+        {"x-rate-limit-minute", ["100extra"]},
+        {"x-minute-requests-left", ["90"]}
+      ]
+
+      rate_limit = Helpers.parse_headers(headers)
+
+      # Only fully numeric values should be parsed
+      assert rate_limit.minute.usage == nil
+      assert rate_limit.minute.limit == nil
+      assert rate_limit.minute.requests_left == 90
+    end
+
+    test "handles empty header list" do
+      rate_limit = Helpers.parse_headers([])
+
+      assert rate_limit.minute.usage == nil
+      assert rate_limit.minute.limit == nil
+      assert rate_limit.minute.requests_left == nil
+
+      assert rate_limit.hourly.usage == nil
+      assert rate_limit.hourly.limit == nil
+      assert rate_limit.hourly.requests_left == nil
+
+      assert rate_limit.daily.usage == nil
+      assert rate_limit.daily.limit == nil
+      assert rate_limit.daily.requests_left == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix crash when Apollo.io returns non-numeric values in rate limit headers
- Use safe integer parsing instead of String.to_integer/1
- Add comprehensive test coverage

## Problem

ContactsAdd component crashes with `ArgumentError: not a textual representation of an integer` when Apollo.io returns non-numeric values (like `"..."`) in rate limit headers.

**AppSignal Incident**: https://appsignal.com/enaia-inc-1/sites/6715e834d2a5e4a48afdb71b/exceptions/incidents/5261

## Changes

- Add `safe_parse_integer/1` helper that uses `Integer.parse/1` for validation
- Initialize rate limit maps with default `nil` values for all keys
- Skip invalid header values gracefully instead of crashing
- Add test file `test/helpers_test.exs` with 4 test cases covering edge cases

## Testing

All new tests pass:
- Parses valid numeric values correctly
- Skips non-numeric values without crashing
- Handles partially numeric strings
- Handles empty header lists